### PR TITLE
Update online-offline-classes.html

### DIFF
--- a/bitcoin-information/online-offline-classes.html
+++ b/bitcoin-information/online-offline-classes.html
@@ -56,49 +56,37 @@
         <div class="text-left col-xs-12 col-sm-6 col-lg-6 col-md-6">
           <h2 id="nontechnical"><a href="#nontechnical">Non-technical Online Classes:</a></h2>
           <ul>
-            <li><a href="https://gohighbrow.com/portfolio/the-basics-of-bitcoin/" title="Bitcoin Basics" target="_blank" rel="noopener">10 Day Email Course: Basics of Bitcoin</a></li>
-            <li><a href="https://learn.saylor.org/course/view.php?id=468" title="Bitcoin for Everybody" target="_blank" rel="noopener">Bitcoin for Everybody</a> (Saylor Academy)</li>
-            <li><a href="https://ocw.mit.edu/courses/15-s12-blockchain-and-money-fall-2018/" title="Blockchain Money" target="_blank" rel="noopener">Blockchain &amp; Money</a> (MIT)</li>
-            <li><a href="https://my.cracktheorange.com/learn-bitcoin-course/" title="Crack the Orange" target="_blank" rel="noopener">Crack the Orange</a> (practical usage)</li>
-            <li><a href="https://ocw.mit.edu/courses/mas-s62-cryptocurrency-engineering-and-design-spring-2018/" title="Cryptocurrency Engineering" target="_blank" rel="noopener">Cryptocurrency Engineering &amp; Design</a> (MIT)</li>
-            <li><a href="https://a16z.com/crypto-startup-school/" title="Crypto Startup School" target="_blank" rel="noopener">Crypto Startup School</a></li>
-            <li><a href="https://bitcoin-explorama.com/" title="Learn Bitcoin Playfully" target="_blank" rel="noopener">Learn Bitcoin Playfully</a></li>
-            <li><a href="https://www.youtube.com/watch?v=MJ0OzrkHvXA&list=PLjyTtFk7i2AHvjMo0-ftIVqSNGPcwCaJt" title="Learn Bitcoin" target="_blank" rel="noopener">Learn Me A Bitcoin Lessons</a></li>
-            <li><a href="https://www.pluralsight.com/courses/bitcoin-decentralized-technology" title="Introduction to Bitcoin" target="_blank" rel="noopener">Introduction to Bitcoin</a> (create a free trial)</li>
-            <li><a href="https://www.ministryofnodes.com.au/" title="Ministry of Nodes" target="_blank" rel="noopener">Ministry of Nodes</a></li>
-            <li><a href="https://planb.network/" title="Plan B Network" target="_blank" rel="noopener">Plan B Network</a></li>
+            <li><a href="https://learn.saylor.org/course/view.php?id=468" title="Bitcoin for Everybody" target="_blank" rel="noopener">Bitcoin for Everybody</a> (Saylor Academy, Course)</li>
+            <li><a href="https://ocw.mit.edu/courses/15-s12-blockchain-and-money-fall-2018/" title="Blockchain Money" target="_blank" rel="noopener">Blockchain &amp; Money</a> (MIT, Course)</li>
+            <li><a href="https://ocw.mit.edu/courses/mas-s62-cryptocurrency-engineering-and-design-spring-2018/" title="Cryptocurrency Engineering" target="_blank" rel="noopener">Cryptocurrency Engineering &amp; Design</a> (MIT, Course)</li>
+            <li><a href="https://bitcoin-explorama.com/" title="Learn Bitcoin Playfully" target="_blank" rel="noopener">Learn Bitcoin Playfully</a> (Online) </li>
+            <li><a href="https://www.youtube.com/watch?v=MJ0OzrkHvXA&list=PLjyTtFk7i2AHvjMo0-ftIVqSNGPcwCaJt" title="Learn Bitcoin" target="_blank" rel="noopener">Learn Me A Bitcoin Lessons</a> (Video Tutorials) </li>
+            <li><a href="https://planb.network/" title="Plan B Network" target="_blank" rel="noopener">Plan B Network</a> (Courses, Free and Paid) </li>
           </ul>
           <h2 id="technical"><a href="#technical">Technical Online Classes:</a></h2>
           <ul>
-            <li><a href="https://base58.school/" title="Base58" target="_blank" rel="noopener">Base58</a></li>
-            <li><a href="https://www.youtube.com/playlist?list=PLzctEq7iZD-7-DgJM604zsndMapn9ff6q" title="Blackboard Series" target="_blank" rel="noopener">Bitcoin 101 Blackboard Series</a> (7+ hours of tutorials)</li>
-            <li><a href="https://www.youtube.com/channel/UCNcSSleedtfyDuhBvOQzFzQ/videos" title="Princeton" target="_blank" rel="noopener">Bitcoin &amp; Cryptocurrency Technologies</a> (Princeton)</li>
-            <li><a href="https://www.youtube.com/channel/UCUq_ZdezVWKPvkWRicAYxLA/videos" title="Developers" target="_blank" rel="noopener">Bitcoin Developer Tutorials</a></li>
-            <li><a href="https://learn.saylor.org/course/view.php?id=500" title="Bitcoin for Developers" target="_blank" rel="noopener">Bitcoin for Developers</a> (Saylor Academy)</li>
-            <li><a href="https://www.bitscript.app/lessons" title="Bitscript" target="_blank" rel="noopener">Bitcoin Script Lessons</a></li>
-            <li><a href="https://github.com/chaincodelabs/bitcoin-curriculum" title="Chaincode Labs Intro" target="_blank" rel="noopener">Bitcoin Protocol Development Curriculum</a> (Chaincode Labs)</li>
-            <li><a href="https://blockchain.studentorg.berkeley.edu/education" title="Blockchain at Berkeley" target="_blank" rel="noopener">Blockchain at Berkeley</a></li>
-            <li><a href="https://btcdemy.thinkific.com/" title="BTCdemy" target="_blank" rel="noopener">BTCdemy</a> (Rust fundamentals for bitcoiners)</li>
-            <li><a href="https://chaincode.gitbook.io/seminars" title="Chaincode Seminars" target="_blank" rel="noopener">Chaincode Online Seminars</a></li>
-            <li><a href="https://www.coursera.org/learn/cryptocurrency" title="Coursera" target="_blank" rel="noopener">Coursera Cryptocurrency Course</a> (61 videos in 11 sections)</li>
-            <li><a href="https://bitcoindevs.xyz/decoding" title="Decoding Bitcoin" target="_blank" rel="noopener">Decoding Bitcoin</a></li>
-            <li><a href="https://www.unic.ac.cy/blockchain/free-mooc/" title="University of Nicosia" target="_blank" rel="noopener">Introduction to Digital Currency</a> - MOOC offered by University of Nicosia</li>
-            <li><a href="https://www.khanacademy.org/economics-finance-domain/core-finance/money-and-banking/bitcoin/v/bitcoin-what-is-it" title="Khan Academy" target="_blank" rel="noopener">Khan Academy Bitcoin Course</a> (9 ~10 minute videos)</li>
-            <li><a href="https://dci.mit.edu/courses/" title="MIT" target="_blank" rel="noopener">MIT DCI's Open Courses</a></li>
-            <li><a href="https://plebdevs.com/" title="PlebDevs" target="_blank" rel="noopener">PlebDevs</a></li>
-            <li><a href="https://www.udemy.com/user/car-gonzalez/" title="Pleb Lab" target="_blank" rel="noopener">Pleb Lab</a></li>
-            <li><a href="https://supertestnet.org/workshops.html" title="SuperTestnet Workshops" target="_blank" rel="noopener">SuperTestnet Workshops</a></li>
-            <li><a href="https://www.udemy.com/bitcoin-or-how-i-learned-to-stop-worrying-and-love-crypto/" title="Udemy" target="_blank" rel="noopener">Udemy Course</a> (over 8 hours of video tutorials)</li>
+            <li><a href="https://www.youtube.com/playlist?list=PLzctEq7iZD-7-DgJM604zsndMapn9ff6q" title="Blackboard Series" target="_blank" rel="noopener">Bitcoin 101 Blackboard Series</a> (7+ hours of Video Tutorials)</li>
+            <li><a href="https://www.youtube.com/channel/UCNcSSleedtfyDuhBvOQzFzQ/videos" title="Princeton" target="_blank" rel="noopener">Bitcoin &amp; Cryptocurrency Technologies</a> (Princeton, Video Tutorials)</li>
+            <li><a href="https://www.youtube.com/channel/UCUq_ZdezVWKPvkWRicAYxLA/videos" title="Developers" target="_blank" rel="noopener">Bitcoin Developer Tutorials</a> (Video Tutorials) </li>
+            <li><a href="https://learn.saylor.org/course/view.php?id=500" title="Bitcoin for Developers" target="_blank" rel="noopener">Bitcoin for Developers I </a> (Saylor Academy, Course)</li>
+            <li><a href="https://www.bitscript.app/lessons" title="Bitscript" target="_blank" rel="noopener">Bitcoin Script Lessons</a> (Bitscript, Lessons) </li>
+            <li><a href="https://github.com/chaincodelabs/bitcoin-curriculum" title="Chaincode Labs Intro" target="_blank" rel="noopener">Bitcoin Protocol Development Curriculum</a> (Github Resources, Chaincode Labs)</li>
+            <li><a href="https://btcdemy.thinkific.com/" title="BTCdemy" target="_blank" rel="noopener">Rust Fundamentals for Bitcoiners</a> (BTCdemy, Online Course)</li>
+            <li><a href="https://chaincode.gitbook.io/seminars" title="Chaincode Seminars" target="_blank" rel="noopener">Chaincode Online Seminars</a> (Chaincode Labs, Online Course BTC/Lightning)</li>
+            <li><a href="https://www.coursera.org/learn/cryptocurrency" title="Coursera" target="_blank" rel="noopener">Coursera Cryptocurrency Course</a> (Princeton, Online Course and over 61 videos)</li>
+            <li><a href="https://bitcoindevs.xyz/decoding" title="Decoding Bitcoin" target="_blank" rel="noopener">Decoding Bitcoin</a> (Chaincode Labs, Online Course)</li>
+            <li><a href="https://www.unic.ac.cy/blockchain/free-mooc/" title="University of Nicosia" target="_blank" rel="noopener">Introduction to Digital Currency</a> (University of Nicosia, Online MOOC)</li>
+            <li><a href="https://www.khanacademy.org/economics-finance-domain/core-finance/money-and-banking/bitcoin/v/bitcoin-what-is-it" title="Khan Academy" target="_blank" rel="noopener">Khan Academy Bitcoin Course</a> (Khan Academy, Video Course)</li>
+            <li><a href="https://ocw.mit.edu/search/?q=bitcoin" title="MIT" target="_blank" rel="noopener">MITOpenCourseware</a>(MIT, Multiple Free Bitcoin Courses and Problem Sets)</li>
+            <li><a href="https://plebdevs.com/" title="PlebDevs" target="_blank" rel="noopener">PlebDevs</a>(PlebDevs, Online Courses)</li>
+            <li><a href="https://supertestnet.org/workshops.html" title="SuperTestnet Workshops" target="_blank" rel="noopener">SuperTestnet Workshops (Bitcoin Script, BISQ, Nostr, Coinjoin Videos)</a></li>
+            <li><a href="https://www.udemy.com/bitcoin-or-how-i-learned-to-stop-worrying-and-love-crypto/" title="Udemy" target="_blank" rel="noopener">Bitcoin or How I Learned to Stop Worrying and Love Crypto</a> (Udemy, 8 hour Video Tutorial)</li>
           </ul>
         </div>
         <!-- RIGHT COLUMN -->
         <div class="text-left col-xs-12 col-sm-6 col-lg-6 col-md-6">
-          <h2 id="offline"><a href="#offline">Technical Offline Classes:</a></h2>
+          <h2 id="offline"><a href="#offline">Technical In Person/Offline Classes:</a></h2>
           <ul>
-            <li><a href="https://www.21lectures.com/" title="21 Lectures" target="_blank" rel="noopener">21 Lectures</a></li>
-            <li><a href="https://residency.chaincode.com/" title="Chaincode" target="_blank" rel="noopener">Chaincode Residency</a></li>
-            <li><a href="https://pleb.fi/" title="Pleb.fi" target="_blank" rel="noopener">Pleb.fi</a></li>
-            <li><a href="https://programmingbitcoin.com/programming-blockchain/" title="Programming Blockchain" target="_blank" rel="noopener">Programming Blockchain</a></li>
           </ul>
           <h2 id="tests"><a href="#tests">Knowledge Tests:</a></h2>
           <ul>


### PR DESCRIPTION
Non technical online classes:
goingighbrow.com: paid bitcoin content, removed.
A16z.com is a poopcoin startup program, removed.
my.cracktheorange.com/learn-bitcoin-course: paid content, removed. Pluralsight.com : dead link
ministryofnodes.com.au: this is a blog and shop, not a course

Technical online Classes:
Base58.school: paid bitcoin content, removed.
https://blockchain.studentorg.berkeley.edu/education: no longer online, in person only, removed. Mit Open Courses: updated link to fix.
Udemy/PlebLabs: Only offers paid courses, removed.

Technical in person/Offline Classes:
21lectures: paid bitcoin course, removed
Residency.chaincode.com: no longer offers conferences pleb.fi: last event was 2023, no longer offering 
Programmingbitcoin.com: $4000 PER STUDENT FEE, removed. Cryptoconsotrium.org: paid crypto books, course "fees" for completing, removed.

Knowledge tests:
Cryptoconsotrium.org: paid crypto books, course "fees" for completing, removed.