### PR TITLE
Lightning History Changes

### DIFF
--- a/lightning.html
+++ b/lightning.html
@@ -62,7 +62,7 @@
           <br>
           <h2 id="history"><a href="#history">History:</a></h2>
           <ul>
-            <li><a href="https://bitcoinmagazine.com/articles/history-lightning-brainstorm-beta/" title="Early History" target="_blank" rel="noopener">Early History</a></li>
+            <li><a href="https://gnusha.org/pi/bitcoindev/CANEZrP2PEB8n_Ov1bXi_ZoAkLwfz7_JtM9PPHr+8ei5KCgwdEg@mail.gmail.com/" title="The first Payment Channel concept on Bitcoin" target="_blank" rel="noopener">The first Payment Channel concept on Bitcoin; Satoshi's idea, as reported by Mike Hearn</a></li>
             <li><a href="https://gcomte.github.io/lightning-timeline" title="Historical Timeline of Developments" target="_blank" rel="noopener">LN Timeline</a></li>
             <li><a href="https://www.youtube.com/watch?v=HauP9F16mUM" title="Historical Video Presentation" target="_blank" rel="noopener">History of LN</a> (Christian Decker)</li>
             <li><a href="https://bitcoinmagazine.com/technical/lightning-torchs-bitcoin-payment-is-running-a-worldwide-marathon" title="History of Lightning Torch" target="_blank" rel="noopener">History of Lightning Torch</a></li>

--- a/lightning.html
+++ b/lightning.html
@@ -64,9 +64,9 @@
           <ul>
             <li><a href="https://gnusha.org/pi/bitcoindev/CANEZrP2PEB8n_Ov1bXi_ZoAkLwfz7_JtM9PPHr+8ei5KCgwdEg@mail.gmail.com/" title="The first Payment Channel concept on Bitcoin" target="_blank" rel="noopener">The first Payment Channel concept on Bitcoin; Satoshi's idea, as reported by Mike Hearn</a></li>
             <li><a href="https://gcomte.github.io/lightning-timeline" title="Historical Timeline of Developments" target="_blank" rel="noopener">LN Timeline</a></li>
-            <li><a href="https://www.youtube.com/watch?v=HauP9F16mUM" title="Historical Video Presentation" target="_blank" rel="noopener">History of LN</a> (Christian Decker)</li>
             <li><a href="https://bitcoinmagazine.com/technical/lightning-torchs-bitcoin-payment-is-running-a-worldwide-marathon" title="History of Lightning Torch" target="_blank" rel="noopener">History of Lightning Torch</a></li>
             <li><a href="https://www.mail-archive.com/lightning-dev@lists.linuxfoundation.org/" title="Lightning Dev Mailing List" target="_blank" rel="noopener">Developer Mailing List Archive</a></li>
+            <li><a href="https://www.youtube.com/watch?v=HauP9F16mUM" title="Historical Video Presentation" target="_blank" rel="noopener">History of LN Video Presentation</a> (Christian Decker)</li>
           </ul>
           <br>
           <h2 id="statistics"><a href="#statistics">Miscellaneous Statistics:</a></h2>


### PR DESCRIPTION
Closes [pithosian#2](https://github.com/pithosian/btc-resources/issues/2), review tracked in that issue.

- Removes Bitcoin Magazine 'Early Lightning History' article.
  - Adds direct link to Linux mailing list archive of Mike Hearn's email describing Satoshi's payment channel.
  - The above email, combined with the timeline, cover everything of note mentioned in the removed Bitcoin Magazine article, if more succinctly, without constant mention of shitcoins.
- Clearly labels the History of LN video presentation as a video presentation.
  - Once the video presentations section has undergone review, I recommend moving it there. Left in place for now to avoid confusion/duplication of review.