### PR TITLE
Update other-resources.html

### DIFF
--- a/bitcoin-information/other-resources.html
+++ b/bitcoin-information/other-resources.html
@@ -56,22 +56,21 @@
         <div class="text-left col-xs-12 col-sm-6 col-lg-6 col-md-6">
           <h2 id="bitcoin"><a href="#bitcoin">Bitcoin Resources:</a></h2>
           <ul>
-            <li><a href="https://github.com/igorbarinov/awesome-bitcoin" title="Awesome Resources" target="_blank" rel="noopener">Awesome Bitcoin Resources</a></li>
-            <li><a href="https://www.athena-alpha.com/" title="Bitcoin Education - Athena Alpha" target="_blank" rel="noopener">Athena Alpha</a></li>
-            <li><a href="https://bitcoinmagazine.com/best-of-bitcoin-magazine" title="Magazine" target="_blank" rel="noopener">Best of Bitcoin Magazine</a></li>
-            <li><a href="https://bitcoindev.org/" title="Developer Resources" target="_blank" rel="noopener">Bitcoin Developer Resources</a></li>
-            <li><a href="https://bitcoinwallets.com/21.html" title="Bitcoin Basics" target="_blank" rel="noopener">Bitcoin History &amp; Fundamentals</a></li>
-            <li><a href="https://hope.com/" title="Hope" target="_blank" rel="noopener">Bitcoin is Hope</a></li>
-            <li><a href="https://bitcoinminds.org/" title="Bitcoin Minds" target="_blank" rel="noopener">Bitcoin Minds</a></li>
-            <li><a href="https://bitcoin-only.com/" title="Bitcoin Only" target="_blank" rel="noopener">Bitcoin Only Resources</a></li>
-            <li><a href="https://bitcoin.rocks/" title="Bitcoin Rocks" target="_blank" rel="noopener">Bitcoin Rocks</a></li>
-            <li><a href="https://bitcoiner.guide/" title="Bitcoiner Guide" target="_blank" rel="noopener">Bitcoiner Guide</a></li>
-            <li><a href="https://github.com/electric-capital/crypto-ecosystems/blob/master/data/ecosystems/b/bitcoin.toml" title="Bitcoin Repositories" target="_blank" rel="noopener">Comprehensive code repository list</a></li>
-            <li><a href="https://dergigi.com/bitcoin/resources/" title="Der Gigi" target="_blank" rel="noopener">Gigi's Bitcoin Resources</a></li>
-            <li><a href="https://repository.spiritofsatoshi.ai/" title="Nakamoto Repository" target="_blank" rel="noopener">Nakamoto Repository</a></li>
-            <li><a href="https://docs.google.com/spreadsheets/d/1Z3Ofa4P8097VWV70Z_bMqIMladngvm-Ck24ot9TDNmw/edit#gid=0" title="Practical Info" target="_blank" rel="noopener">Practical Bitcoin Info</a></li>
-            <li><a href="https://river.com/learn/" title="River" target="_blank" rel="noopener">River's Bitcoin Learning Center</a></li>
-            <li><a href="https://svrgnty.com/" title="Svrgnty.com" target="_blank" rel="noopener">Svrgnty.com: A curated list of the best Bitcoin resources</a></li>
+            <li><a href="https://river.com/learn/" title="River" target="_blank" rel="noopener">River's Bitcoin Learning Center</a> Beginner Friendly Bitcoin Learning/Resources </li>
+	    <li><a href="https://svrgnty.com/" title="Svrgnty.com" target="_blank" rel="noopener">Svrgnty.com</a> A curated list of the Best Bitcoin resources </li>
+	    <li><a href="https://bitcoin.rocks/" title="Bitcoin Rocks" target="_blank" rel="noopener">Bitcoin Rocks!</a> More Beginner Friendly Bitcoin Learning/Resources </li>
+            <li><a href="https://github.com/igorbarinov/awesome-bitcoin" title="Awesome Resources" target="_blank" rel="noopener">Awesome Bitcoin Resources</a> Utilities, API, Libraries, Books, Etc </li>
+	    <li><a href="https://www.athena-alpha.com/" title="Bitcoin Education - Athena Alpha" target="_blank" rel="noopener">Athena Alpha</a> Scroll to Bottom for Free Articles </li>
+            <li><a href="https://bitcoinmagazine.com/best-of-bitcoin-magazine" title="Magazine" target="_blank" rel="noopener">Best of Bitcoin Magazine</a> Articles </li>
+            <li><a href="https://bitcoindev.org/" title="Developer Resources" target="_blank" rel="noopener">Bitcoin Developer Resources</a> Podcasts, Conferences, Meetups, Discussions, Competitions, Contributions, Funding, Jobs </li>
+            <li><a href="https://bitcoinwallets.com/21.html" title="Bitcoin Basics" target="_blank" rel="noopener">Bitcoin History &amp; Fundamentals</a> Scroll to Bottom for Good Timeline/History of Bitcoin </li>
+            <li><a href="https://hope.com/" title="Hope" target="_blank" rel="noopener">Bitcoin is Hope</a> Microstrategy Podcasts and Interviews. WARNING: MSTR IS NOT BITCOIN!!! </li>
+            <li><a href="https://bitcoinminds.org/" title="Bitcoin Minds" target="_blank" rel="noopener">Bitcoin Minds</a> Database of 900+ Bitcoin Resouces (Articles, Books, Podcasts, Guides). Hasn't been updated much since 2022 </li>
+            <li><a href="https://bitcoin-only.com/" title="Bitcoin Only" target="_blank" rel="noopener">Bitcoin-Only.com</a> Good Collection of Bitcoin Resources </li>
+            <li><a href="https://bitcoiner.guide/" title="Bitcoiner Guide" target="_blank" rel="noopener">Bitcoiner.Guide</a> A Collection of Bitcoin Resources by QnA </li>
+            <li><a href="https://github.com/electric-capital/crypto-ecosystems/tree/master" title="Bitcoin Repositories" target="_blank" rel="noopener">Crypto Ecosystems</a> A taxonomy of open source blockchain, web3, cryptocurrency, and decentralized ecosystems and their code repositories </li>
+            <li><a href="https://dergigi.com/bitcoin/resources/" title="Der Gigi" target="_blank" rel="noopener">Gigi's Bitcoin Resources</a> Bitcoin Videos, Books, Articles, Podcasts </li>
+            <li><a href="https://docs.google.com/spreadsheets/d/1Z3Ofa4P8097VWV70Z_bMqIMladngvm-Ck24ot9TDNmw/edit#gid=0" title="Practical Info" target="_blank" rel="noopener">Practical Bitcoin Info</a> Google Sheet with 500+ Links to BItcoin Resources. Block explorers, Privacy, Wallets, Development, Trading, Etc</li>
           </ul>
         </div>
         <!-- RIGHT COLUMN -->
@@ -98,13 +97,13 @@
             <li><a href="https://www.bitcoinsverige.org/" title="Bitcoin resources in Swedish" target="_blank" rel="noopener">Bitcoin -resurser på Svenska</a></li>
             <li><a href="https://www.21ideas.org/" title="Bitcoin resources in Russian" target="_blank" rel="noopener">Биткоин-ресурсы на русском языке</a></li>
           </ul>
-          <h2 id="blockchain"><a href="#blockchain">Blockchain &amp; Crypto Resources:</a></h2>
+          <!--<h2 id="blockchain"><a href="#blockchain">Blockchain &amp; Crypto Resources:</a></h2>
           <ul>
-            <li><a href="https://github.com/0xtokens/awesome-blockchain" title="Awesome Blockchain" target="_blank" rel="noopener">Awesome Blockchain Resources</a></li>
+            -<li><a href="https://github.com/0xtokens/awesome-blockchain" title="Awesome Blockchain" target="_blank" rel="noopener">Awesome Blockchain Resources</a></li>
             <li><a href="https://github.com/jlopp/Blockchain-stuff" title="Blockchain Stuff" target="_blank" rel="noopener">Blockchain Stuff</a></li>
             <li><a href="https://github.com/coinpride/CryptoList" title="CoinPride" target="_blank" rel="noopener">CoinPride's CryptoList</a></li>
             <li><a href="https://cryptolinks.com/" title="Crypto Links" target="_blank" rel="noopener">Crypto Links</a></li>
-          </ul>
+          </ul>-->
         </div>
       </div>
     </div>


### PR DESCRIPTION
Moved beginner friendly stuff to the top.

Added some basic descriptions to resources.

I dont like bitcoinmagazine.com, but I didnt remove the link since i cant find any direct shitcoinery.

Crypto Ecosystems- fixed link

Nakamoto Repository - Site no longer exists, removed

Removed Blockchain & Crypto Resources section: WAY too many links to shitcoins, shitcoin exchanges.