### PR TITLE
Update news.html

### DIFF
--- a/bitcoin-information/news.html
+++ b/bitcoin-information/news.html
@@ -56,16 +56,10 @@
         <div class="text-left col-xs-12 col-sm-6 col-lg-6 col-md-6">
           <h2 id="news"><a href="#news">News Sites:</a></h2>
           <ul>
-            <li><a href="https://beincrypto.com/" title="Be In Crypto" target="_blank" rel="noopener">BeInCrypto</a></li>
-            <li><a href="https://bitcoinmagazine.com/" title="Bitcoin Magazine" target="_blank" rel="noopener">Bitcoin Magazine</a></li>
             <li><a href="http://bitcoinnews.com/" title="Bitcoin News" target="_blank" rel="noopener">Bitcoin News</a></li>
             <li><a href="https://bitcoinops.org/en/newsletters/" title="Bitcoin Optech" target="_blank" rel="noopener">Bitcoin Optech Newsletter</a></li>
             <li><a href="https://www.btctimes.com/" title="BTC Times" target="_blank" rel="noopener">BTC Times</a></li>
-            <li><a href="http://www.coindesk.com/" title="Coindesk" target="_blank" rel="noopener">Coindesk</a></li>
-            <li><a href="https://finbold.com/" title="Finbold" target="_blank" rel="noopener">Finbold</a></li>
-            <li><a href="https://messari.io/" title="Messari" target="_blank" rel="noopener">Messari</a></li>
             <li><a href="https://www.nobsbitcoin.com/" title="No BS Bitcoin" target="_blank" rel="noopener">No BS Bitcoin</a></li>
-            <li><a href="https://onepagecrypto.com/" title="One Page Crypto" target="_blank" rel="noopener">One Page Crypto</a> (aggregator)</li>
           </ul>
         </div>
         <!-- RIGHT COLUMN -->


### PR DESCRIPTION
Removed Links for BeInCrypto, Coindesk, Finbold as they all seem to be dabbling in shitcoins. 
Removed link for Bitcoin Magazine as it is focused too much on custodial bitcoin (bitcoin treasuries). 
Removed Link for One Page Crypto as site is now dead. 